### PR TITLE
Added dbname

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -1,3 +1,4 @@
 {
-  "port": 5000
+  "port": 5000,
+  "dbname": "blazing-bookkeeper"
 }


### PR DESCRIPTION
Added dbname to `config.json` show we get `blazing-bookkeeper` as database name instead of `undefined`